### PR TITLE
Bring back progressive loading

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,15 +7,34 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		005656EB1A6EE471008A0ED1 /* Gifu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 005656EA1A6EE471008A0ED1 /* Gifu.framework */; };
 		9D25870819BCCB0F00A55A18 /* mugen.gif in Resources */ = {isa = PBXBuildFile; fileRef = 9D25870619BCCB0F00A55A18 /* mugen.gif */; };
 		9D98823D19BC69CA00B790C6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D98823C19BC69CA00B790C6 /* AppDelegate.swift */; };
 		9D98823F19BC69CA00B790C6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D98823E19BC69CA00B790C6 /* ViewController.swift */; };
 		9D98824419BC69CA00B790C6 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9D98824319BC69CA00B790C6 /* Images.xcassets */; };
 		9D98825A19BC69F600B790C6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9D98825919BC69F600B790C6 /* Main.storyboard */; };
 		9D98826719BC874C00B790C6 /* FlatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D98826619BC874C00B790C6 /* FlatButton.swift */; };
+		EA5789A01B20C5B100A9F7D1 /* almost_nailed_it.gif in Resources */ = {isa = PBXBuildFile; fileRef = EA57899F1B20C5B100A9F7D1 /* almost_nailed_it.gif */; };
+		EA5789A71B20C65E00A9F7D1 /* Gifu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA5789A61B20C65800A9F7D1 /* Gifu.framework */; };
+		EA5789A91B20C68B00A9F7D1 /* Gifu.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EA5789A61B20C65800A9F7D1 /* Gifu.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EA9299291AE99E2900E22976 /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA9299281AE99E2900E22976 /* Runes.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		EA5789A51B20C65800A9F7D1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EA5789A11B20C65800A9F7D1 /* Gifu.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 00B8C73E1A364DA400C188E7;
+			remoteInfo = Gifu;
+		};
+		EA5789AA1B20C68B00A9F7D1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EA5789A11B20C65800A9F7D1 /* Gifu.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 00B8C73D1A364DA400C188E7;
+			remoteInfo = Gifu;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		00B8C7331A364D4C00C188E7 /* Embed Frameworks */ = {
@@ -24,6 +43,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				EA5789A91B20C68B00A9F7D1 /* Gifu.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -31,7 +51,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		005656EA1A6EE471008A0ED1 /* Gifu.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Gifu.framework; path = "../../build/Debug-iphoneos/Gifu.framework"; sourceTree = "<group>"; };
 		9D25870519BCCB0F00A55A18 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9D25870619BCCB0F00A55A18 /* mugen.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = mugen.gif; sourceTree = "<group>"; };
 		9D98823719BC69CA00B790C6 /* gifu-demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "gifu-demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -40,6 +59,8 @@
 		9D98824319BC69CA00B790C6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		9D98825919BC69F600B790C6 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		9D98826619BC874C00B790C6 /* FlatButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FlatButton.swift; path = classes/FlatButton.swift; sourceTree = "<group>"; };
+		EA57899F1B20C5B100A9F7D1 /* almost_nailed_it.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = almost_nailed_it.gif; sourceTree = "<group>"; };
+		EA5789A11B20C65800A9F7D1 /* Gifu.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Gifu.xcodeproj; path = ../Gifu.xcodeproj; sourceTree = "<group>"; };
 		EA9299281AE99E2900E22976 /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = ../Carthage/Build/iOS/Runes.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -48,8 +69,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				005656EB1A6EE471008A0ED1 /* Gifu.framework in Frameworks */,
 				EA9299291AE99E2900E22976 /* Runes.framework in Frameworks */,
+				EA5789A71B20C65E00A9F7D1 /* Gifu.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,16 +111,25 @@
 		9D98823A19BC69CA00B790C6 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				005656EA1A6EE471008A0ED1 /* Gifu.framework */,
 				9D25870519BCCB0F00A55A18 /* Info.plist */,
+				EA57899F1B20C5B100A9F7D1 /* almost_nailed_it.gif */,
 				9D25870619BCCB0F00A55A18 /* mugen.gif */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		EA5789A21B20C65800A9F7D1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EA5789A61B20C65800A9F7D1 /* Gifu.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		EA92992C1AE9AB2100E22976 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EA5789A11B20C65800A9F7D1 /* Gifu.xcodeproj */,
 				EA9299281AE99E2900E22976 /* Runes.framework */,
 			);
 			name = Frameworks;
@@ -121,6 +151,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				EA5789AB1B20C68B00A9F7D1 /* PBXTargetDependency */,
 			);
 			name = "gifu-demo";
 			productName = "gifu-demo";
@@ -152,6 +183,12 @@
 			mainGroup = 9D98822E19BC69CA00B790C6;
 			productRefGroup = 9D98823819BC69CA00B790C6 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = EA5789A21B20C65800A9F7D1 /* Products */;
+					ProjectRef = EA5789A11B20C65800A9F7D1 /* Gifu.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				9D98823619BC69CA00B790C6 /* gifu-demo */,
@@ -159,11 +196,22 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXReferenceProxy section */
+		EA5789A61B20C65800A9F7D1 /* Gifu.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Gifu.framework;
+			remoteRef = EA5789A51B20C65800A9F7D1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
 /* Begin PBXResourcesBuildPhase section */
 		9D98823519BC69CA00B790C6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA5789A01B20C5B100A9F7D1 /* almost_nailed_it.gif in Resources */,
 				9D98824419BC69CA00B790C6 /* Images.xcassets in Resources */,
 				9D25870819BCCB0F00A55A18 /* mugen.gif in Resources */,
 				9D98825A19BC69F600B790C6 /* Main.storyboard in Resources */,
@@ -201,6 +249,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		EA5789AB1B20C68B00A9F7D1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Gifu;
+			targetProxy = EA5789AA1B20C68B00A9F7D1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		9D98825119BC69CA00B790C6 /* Debug */ = {

--- a/Demo/demo/Main.storyboard
+++ b/Demo/demo/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -46,6 +46,19 @@
                                     <action selector="toggleAnimation:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="PvH-3E-LbB"/>
                                 </connections>
                             </button>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="tZ1-rw-Kbd">
+                                <rect key="frame" x="236" y="467" width="129" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="VXm-pK-heN"/>
+                                </constraints>
+                                <segments>
+                                    <segment title="Mugen"/>
+                                    <segment title="Nailed It"/>
+                                </segments>
+                                <connections>
+                                    <action selector="toggleGIF:" destination="vXZ-lx-hvc" eventType="valueChanged" id="W0R-yI-ahi"/>
+                                </connections>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" red="0.24722154438495636" green="0.26659342646598816" blue="0.2988148033618927" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
@@ -56,7 +69,10 @@
                             <constraint firstAttribute="centerX" secondItem="c8Y-41-BaC" secondAttribute="centerX" id="Kc0-P5-KMZ"/>
                             <constraint firstItem="FSz-xF-Xds" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="8" id="O4L-QH-SvV"/>
                             <constraint firstItem="bFY-3J-OXr" firstAttribute="top" secondItem="FSz-xF-Xds" secondAttribute="bottom" constant="50" id="PKi-91-olI"/>
+                            <constraint firstAttribute="centerX" secondItem="tZ1-rw-Kbd" secondAttribute="centerX" id="QKy-Gl-KPQ"/>
+                            <constraint firstItem="bFY-3J-OXr" firstAttribute="top" secondItem="tZ1-rw-Kbd" secondAttribute="bottom" constant="14" id="Vqv-f1-dnH"/>
                             <constraint firstItem="wsv-cU-WO5" firstAttribute="top" secondItem="c8Y-41-BaC" secondAttribute="bottom" constant="4" id="ZG4-fK-WvN"/>
+                            <constraint firstItem="tZ1-rw-Kbd" firstAttribute="top" secondItem="FSz-xF-Xds" secondAttribute="bottom" constant="8" id="lu2-sK-QNZ"/>
                             <constraint firstAttribute="centerX" secondItem="FSz-xF-Xds" secondAttribute="centerX" id="oih-yH-vRh"/>
                             <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="bFY-3J-OXr" secondAttribute="bottom" constant="41" id="w4g-Xu-ht2"/>
                             <constraint firstAttribute="centerX" secondItem="wsv-cU-WO5" secondAttribute="centerX" id="yLb-zR-gfU"/>

--- a/Demo/demo/classes/ViewController.swift
+++ b/Demo/demo/classes/ViewController.swift
@@ -9,7 +9,7 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    imageView.animateWithImage(named: "almost_nailed_it.gif")
+    imageView.animateWithImage(named: "mugen.gif")
 
     UIApplication.sharedApplication().setStatusBarStyle(.LightContent, animated: false)
   }
@@ -23,6 +23,16 @@ class ViewController: UIViewController {
       imageView.startAnimatingGIF()
       button.layer.backgroundColor = UIColor.clearColor().CGColor
       button.setTitleColor(UIColor.whiteColor(), forState: .Normal)
+    }
+  }
+
+  @IBAction func toggleGIF(sender: UISegmentedControl) {
+    imageView.stopAnimatingGIF()
+
+    switch sender.selectedSegmentIndex {
+    case 0: imageView.animateWithImage(named: "mugen.gif")
+    case 1: imageView.animateWithImage(named: "almost_nailed_it.gif")
+    default: imageView.image = .None
     }
   }
 }

--- a/Demo/demo/classes/ViewController.swift
+++ b/Demo/demo/classes/ViewController.swift
@@ -9,7 +9,7 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    imageView.animateWithImage(named: "mugen.gif")
+    imageView.animateWithImage(named: "almost_nailed_it.gif")
 
     UIApplication.sharedApplication().setStatusBarStyle(.LightContent, animated: false)
   }

--- a/Gifu.xcodeproj/project.pbxproj
+++ b/Gifu.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		005656ED1A6F14D6008A0ED1 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005656EC1A6F14D6008A0ED1 /* Animator.swift */; };
 		005656EF1A6F1C26008A0ED1 /* AnimatableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005656EE1A6F1C26008A0ED1 /* AnimatableImageView.swift */; };
-		005656F11A7042E9008A0ED1 /* Animatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005656F01A7042E9008A0ED1 /* Animatable.swift */; };
 		00B8C75F1A364DCE00C188E7 /* ImageSourceHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B8C75C1A364DCE00C188E7 /* ImageSourceHelpers.swift */; };
 		00B8C7961A3650EE00C188E7 /* Gifu.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8C7951A3650EE00C188E7 /* Gifu.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA1E21131AD5D369000459BD /* Runes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA1E21121AD5D369000459BD /* Runes.framework */; };
@@ -21,7 +20,6 @@
 /* Begin PBXFileReference section */
 		005656EC1A6F14D6008A0ED1 /* Animator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animator.swift; sourceTree = "<group>"; };
 		005656EE1A6F1C26008A0ED1 /* AnimatableImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatableImageView.swift; sourceTree = "<group>"; };
-		005656F01A7042E9008A0ED1 /* Animatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animatable.swift; sourceTree = "<group>"; };
 		00B8C73E1A364DA400C188E7 /* Gifu.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gifu.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		00B8C7421A364DA400C188E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Source/Info.plist; sourceTree = "<group>"; };
 		00B8C75C1A364DCE00C188E7 /* ImageSourceHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageSourceHelpers.swift; sourceTree = "<group>"; };
@@ -77,7 +75,6 @@
 				005656EE1A6F1C26008A0ED1 /* AnimatableImageView.swift */,
 				EAF49CB01A3B6EEB00B395DF /* AnimatedFrame.swift */,
 				005656EC1A6F14D6008A0ED1 /* Animator.swift */,
-				005656F01A7042E9008A0ED1 /* Animatable.swift */,
 				00B8C7951A3650EE00C188E7 /* Gifu.h */,
 				00B8C75C1A364DCE00C188E7 /* ImageSourceHelpers.swift */,
 				EAF49C7E1A3A4DE000B395DF /* UIImageExtension.swift */,
@@ -175,7 +172,6 @@
 				005656EF1A6F1C26008A0ED1 /* AnimatableImageView.swift in Sources */,
 				005656ED1A6F14D6008A0ED1 /* Animator.swift in Sources */,
 				EAF49CB11A3B6EEB00B395DF /* AnimatedFrame.swift in Sources */,
-				005656F11A7042E9008A0ED1 /* Animatable.swift in Sources */,
 				00B8C75F1A364DCE00C188E7 /* ImageSourceHelpers.swift in Sources */,
 				EAF49C811A3A4FAA00B395DF /* Curry.swift in Sources */,
 				EAF49C7F1A3A4DE000B395DF /* UIImageExtension.swift in Sources */,

--- a/Source/Animatable.swift
+++ b/Source/Animatable.swift
@@ -1,7 +1,0 @@
-/// Protocol that requires its members to have a `layer`, `frame`, and `contentMode` property.
-/// Classes confirming to this protocol can serve as a delegate to `Animator`.
-protocol Animatable {
-  var layer: CALayer { get }
-  var frame: CGRect { get }
-  var contentMode: UIViewContentMode { get }
-}

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -7,6 +7,10 @@ public class AnimatableImageView: UIImageView, Animatable {
   /// An `Animator` instance that holds the frames of a specific image in memory.
   var animator: Animator?
 
+  deinit {
+    println("deinit animatable view")
+  }
+
   /// A computed property that returns whether the image view is animating.
   public var isAnimatingGIF: Bool {
     return animator?.isAnimating ?? isAnimating()
@@ -58,6 +62,10 @@ public class AnimatableImageView: UIImageView, Animatable {
   /// Stops the image view animation.
   public func stopAnimatingGIF() {
     animator?.pauseAnimation() ?? stopAnimating()
+  }
+
+  public func cleanup() {
+    animator = .None
   }
 }
 


### PR DESCRIPTION
Loading the all the frames of a GIF at once into memory helped cut down
on the memory footprint because we could eliminate the need to hold onto
the source image. However, we see this break down when there are too
many frames. The "almost_nailed_it.gif" GIF has 545 frames and would
crash the app around 130 loaded. This brings back progressive loading
with a max frame count of 50 to prevent this issue.