### PR TITLE
Fixed Array Index Out of range bug

### DIFF
--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -91,6 +91,11 @@ class Animator {
   func updateCurrentFrame(duration: CFTimeInterval) -> Bool {
     timeSinceLastFrameChange += min(maxTimeStep, duration)
     var frameDuration = animatedFrames[currentFrameIndex].duration
+    
+    //If there are no frames to animate, crashes with array index out of range
+    if animatedFrames.count == 0 {
+        return false
+    }
 
     if timeSinceLastFrameChange >= frameDuration {
       timeSinceLastFrameChange -= frameDuration

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -90,12 +90,13 @@ class Animator {
   /// :returns: An optional image at a given frame.
   func updateCurrentFrame(duration: CFTimeInterval) -> Bool {
     timeSinceLastFrameChange += min(maxTimeStep, duration)
-    var frameDuration = animatedFrames[currentFrameIndex].duration
     
     //If there are no frames to animate, crashes with array index out of range
     if animatedFrames.count == 0 {
         return false
     }
+    
+    var frameDuration = animatedFrames[currentFrameIndex].duration
 
     if timeSinceLastFrameChange >= frameDuration {
       timeSinceLastFrameChange -= frameDuration


### PR DESCRIPTION
When using background threads and then updating the ui on the main thread, there is a small chance that there are no frames to animate, so the animatedFrames is 0, and the index is out of range.  If you check and return false then its fine.