### PR TITLE
Adding a reset function

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -68,7 +68,7 @@ public class AnimatableImageView: UIImageView {
   }
   
   /// Reset the image view values
-  public func resetAnimationView() {
+  public func prepareForReuse() {
     stopAnimatingGIF()
     animator = nil
   }

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -66,6 +66,12 @@ public class AnimatableImageView: UIImageView {
   public func stopAnimatingGIF() {
     displayLink.paused = true
   }
+  
+  /// Reset the image view values
+  public func resetAnimationView() {
+    stopAnimatingGIF()
+    animator = nil
+  }
 
   /// Update the current frame with the displayLink duration
   func updateFrame() {


### PR DESCRIPTION
If Gifu is used within a UITableViewCell, there's no way to reset/nullify the animator directly. Otherwise, the UITableViewCell reuse do not complete cleanly.

Please review.
N.