### PR TITLE
Add possibility to disable pre-scaling

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -10,6 +10,9 @@ public class AnimatableImageView: UIImageView {
   /// The size of the frame cache.
   public var framePreloadCount = 50
 
+  /// Specifies whether a scaled version of each GIF frame that matches the current size of the image view should be created. Default is **true**.
+  public var needsPrescaling = true
+  
   /// A computed property that returns whether the image view is animating.
   public var isAnimatingGIF: Bool {
     return !displayLink.paused

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -33,8 +33,11 @@ public class AnimatableImageView: UIImageView {
   public func prepareForAnimation(imageData data: NSData) {
     image = UIImage(data: data)
     animator = Animator(data: data, size: frame.size, contentMode: contentMode, framePreloadCount: framePreloadCount)
-    animator?.prepareFrames()
-    attachDisplayLink()
+    if let animator = animator {
+      animator.needsPrescaling = self.needsPrescaling
+      animator.prepareFrames()
+      attachDisplayLink()
+    }
   }
 
   /// Prepares the frames using a GIF image file name and starts animating the image view.

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -33,11 +33,9 @@ public class AnimatableImageView: UIImageView {
   public func prepareForAnimation(imageData data: NSData) {
     image = UIImage(data: data)
     animator = Animator(data: data, size: frame.size, contentMode: contentMode, framePreloadCount: framePreloadCount)
-    if let animator = animator {
-      animator.needsPrescaling = self.needsPrescaling
-      animator.prepareFrames()
-      attachDisplayLink()
-    }
+    animator?.needsPrescaling = self.needsPrescaling
+    animator?.prepareFrames()
+    attachDisplayLink()
   }
 
   /// Prepares the frames using a GIF image file name and starts animating the image view.

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -23,6 +23,9 @@ class Animator {
   var currentPreloadIndex = 0
   /// Time elapsed since the last frame change. Used to determine when the frame should be updated.
   var timeSinceLastFrameChange: NSTimeInterval = 0.0
+  /// Specifies whether GIF images pre-scaling is needed.
+  /// - seealso: `needsPrescaling` in AnimatableImageView.
+  var needsPrescaling = true
 
   /// The current image frame to show.
   var currentFrame: UIImage? {

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -72,11 +72,16 @@ class Animator {
     let image = UIImage(CGImage: frameImageRef)
     let scaledImage: UIImage?
 
-    switch contentMode {
-    case .ScaleAspectFit: scaledImage = image.resizeAspectFit(size)
-    case .ScaleAspectFill: scaledImage = image.resizeAspectFill(size)
-    default: scaledImage = image.resize(size)
+    if needsPrescaling == true {
+      switch contentMode {
+      case .ScaleAspectFit: scaledImage = image.resizeAspectFit(size)
+      case .ScaleAspectFill: scaledImage = image.resizeAspectFill(size)
+      default: scaledImage = image.resize(size)
+      }
+    } else {
+      scaledImage = image
     }
+
 
     return AnimatedFrame(image: scaledImage, duration: frameDuration)
   }


### PR DESCRIPTION
With the help of needsPrescaling public property it is possible for users to disable GIF images pre-scaling. This can be useful if we already have pre-scaled GIF and we don't wanna waste time calling the resizing functions. Also, I think, this closes #36. 