### PR TITLE
Add a poster image public property

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -76,6 +76,7 @@ public class AnimatableImageView: UIImageView {
     stopAnimatingGIF()
     animator = nil
     posterImage = nil
+    image = nil
   }
 
   /// Update the current frame with the displayLink duration

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -9,6 +9,9 @@ public class AnimatableImageView: UIImageView {
 
   /// The size of the frame cache.
   public var framePreloadCount = 50
+  
+  /// A preview image extracted from the first frame of an animated GIF.
+  public var posterImage: UIImage?
 
   /// A computed property that returns whether the image view is animating.
   public var isAnimatingGIF: Bool {

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -75,6 +75,7 @@ public class AnimatableImageView: UIImageView {
   public func prepareForReuse() {
     stopAnimatingGIF()
     animator = nil
+    posterImage = nil
   }
 
   /// Update the current frame with the displayLink duration

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -31,10 +31,10 @@ public class AnimatableImageView: UIImageView {
   ///
   /// - parameter data: GIF image data.
   public func prepareForAnimation(imageData data: NSData) {
-    image = UIImage(data: data)
     animator = Animator(data: data, size: frame.size, contentMode: contentMode, framePreloadCount: framePreloadCount)
     animator?.prepareFrames()
     posterImage = (animator?.animatedFrames.count > 0) ? animator?.animatedFrames[0].image : nil
+    image = posterImage
     attachDisplayLink()
   }
 

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -34,6 +34,7 @@ public class AnimatableImageView: UIImageView {
     image = UIImage(data: data)
     animator = Animator(data: data, size: frame.size, contentMode: contentMode, framePreloadCount: framePreloadCount)
     animator?.prepareFrames()
+    posterImage = (animator?.animatedFrames.count > 0) ? animator?.animatedFrames[0].image : nil
     attachDisplayLink()
   }
 


### PR DESCRIPTION
This _posterImage_ property can be used to get a preview image of an animated GIF.