### PR TITLE
Move an animation to a specific frame

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -71,6 +71,7 @@ public class AnimatableImageView: UIImageView {
   /// - parameter index: Index the animation must be moved to.
   public func moveToFrame(index: Int) {
     guard let animator = animator else { return }
+    if animator.currentMoveIndex == index || index < 0 || index >= animator.frameCount { return }
     
     stopAnimatingGIF()
     image = animator.prepareFrame(index).image

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -58,6 +58,11 @@ public class AnimatableImageView: UIImageView {
   /// Starts the image view animation.
   public func startAnimatingGIF() {
     if animator?.isAnimatable ?? false {
+      // Check whether the animation was moved.
+      if (animator?.currentMoveIndex ?? -1) >= 0 {
+        prepareForPlayAfterMoving()
+      }
+      
       displayLink.paused = false
     }
   }

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -83,6 +83,11 @@ public class AnimatableImageView: UIImageView {
     stopAnimatingGIF()
     animator = nil
   }
+  
+  /// Updates cache to correctly continue GIF playing.
+  func prepareForPlayAfterMoving() {
+    animator?.prepareFramesAfterMoving()
+  }
 
   /// Update the current frame with the displayLink duration
   func updateFrame() {

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -67,6 +67,15 @@ public class AnimatableImageView: UIImageView {
     displayLink.paused = true
   }
   
+  /// Moves the GIF animation to the given frame index.
+  /// - parameter index: Index the animation must be moved to.
+  public func moveToFrame(index: Int) {
+    guard let animator = animator else { return }
+    
+    stopAnimatingGIF()
+    image = animator.prepareFrame(index).image
+  }
+  
   /// Reset the image view values
   public func prepareForReuse() {
     stopAnimatingGIF()

--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -74,6 +74,7 @@ public class AnimatableImageView: UIImageView {
     
     stopAnimatingGIF()
     image = animator.prepareFrame(index).image
+    animator.currentMoveIndex = index
   }
   
   /// Reset the image view values

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -108,4 +108,24 @@ class Animator {
     
     return true
   }
+  
+  /// Rebuilds cache using currentMoveIndex as the starting index.
+  func rebuildFrameCache() {
+    if currentMoveIndex < 0 { return }
+    
+    // Calculate indices of the frames that require preloading.
+    var indicesForPreload = [Int](count: animatedFrames.count, repeatedValue: 0)
+    var baseIndex = currentMoveIndex
+    for indexForPreload in (0..<indicesForPreload.count) {
+      indicesForPreload[indexForPreload] = baseIndex % frameCount
+      ++baseIndex
+    }
+    
+    // Fill the cache with the new animated frames.
+    animatedFrames = indicesForPreload.reduce([]) { $0 + pure(prepareFrame($1)) }
+
+    // Reset currently invalid indices.
+    currentPreloadIndex = baseIndex % frameCount
+    currentFrameIndex = 0
+  }
 }

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -144,7 +144,7 @@ class Animator {
     var baseIndex = currentMoveIndex
     for indexForPreload in (0..<indicesForPreload.count) {
       indicesForPreload[indexForPreload] = baseIndex % frameCount
-      ++baseIndex
+      baseIndex += 1
     }
     
     // Fill the cache with the new animated frames.

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -21,6 +21,8 @@ class Animator {
   var currentFrameIndex = 0
   /// The index of the current GIF frame from the source.
   var currentPreloadIndex = 0
+  /// The idnex of the current GIF frame the animation was moved to. -1 means the animation wasn't moved.
+  var currentMoveIndex = -1
   /// Time elapsed since the last frame change. Used to determine when the frame should be updated.
   var timeSinceLastFrameChange: NSTimeInterval = 0.0
 

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -79,6 +79,22 @@ class Animator {
 
     return AnimatedFrame(image: scaledImage, duration: frameDuration)
   }
+  
+  /// Updates the cached frames and indices in case the animation was moved to an arbitrary frame.
+  func prepareFramesAfterMoving() {
+    // Check whether cache rebuilding is needed.
+    if animatedFrames.count == frameCount {
+      currentFrameIndex = currentMoveIndex
+    } else {
+      rebuildFrameCache()
+    }
+    
+    // Reset updating time.
+    timeSinceLastFrameChange = 0.0
+    
+    // Reset move index.
+    currentMoveIndex = -1
+  }
 
   /// Returns the frame at a particular index.
   ///

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -129,6 +129,9 @@ class Animator {
   func rebuildFrameCache() {
     if currentMoveIndex < 0 { return }
     
+    // Check whether move index matches current animation position.
+    if ((currentMoveIndex + animatedFrames.count) % frameCount) == currentPreloadIndex { return }
+    
     // Calculate indices of the frames that require preloading.
     var indicesForPreload = [Int](count: animatedFrames.count, repeatedValue: 0)
     var baseIndex = currentMoveIndex


### PR DESCRIPTION
_moveToFrame_ public function makes it possible to move an animation to a required GIF frame. It works according to the following algorithm: 
1) Stop currently played animation;
2) Extract GIF frame in accordance with the given index;
3) Display this frame;
4) Rebuild the cache (_animatedFrames_ array) during the next animation starting procedure.
