### PR TITLE
Update AnimatableImageView.swift

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -5,7 +5,7 @@ public class AnimatableImageView: UIImageView {
   /// An `Animator` instance that holds the frames of a specific image in memory.
   var animator: Animator?
   /// A display link that keeps calling the `updateFrame` method on every screen refresh.
-  lazy var displayLink: CADisplayLink = CADisplayLink(target: self, selector: Selector("updateFrame"))
+  lazy var displayLink: CADisplayLink = CADisplayLink(target: self, selector: #selector(updateFrame))
 
   /// The size of the frame cache.
   public var framePreloadCount = 50


### PR DESCRIPTION
Update to iOS 9.3 #selector() syntax.