### PR TITLE
Conditionally invalidate the displayLink

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -19,10 +19,14 @@ public class AnimatableImageView: UIImageView {
   /// An `Animator` instance that holds the frames of a specific image in memory.
   var animator: Animator?
 
+  /// A flag to avoid invalidating the displayLink on deinit if it was never created
+  private var displayLinkInitialized: Bool = false
+
   /// A display link that keeps calling the `updateFrame` method on every screen refresh.
   lazy var displayLink: CADisplayLink = {
     let display = CADisplayLink(target: TargetProxy(target: self), selector: #selector(TargetProxy.onScreenUpdate))
     display.paused = true
+    self.displayLinkInitialized = true
     return display
   }()
 
@@ -110,8 +114,10 @@ public class AnimatableImageView: UIImageView {
 
   /// Invalidate the displayLink so it releases its target.
   deinit {
-    // invalidate will also remove the link from all run loops
-    displayLink.invalidate()
+    if displayLinkInitialized {
+      // invalidate will also remove the link from all run loops
+      displayLink.invalidate()
+    }
   }
 
   /// Attaches the display link.


### PR DESCRIPTION
Don't invalidate the displayLink if it was never initialized before the AnimatableImageView is deallocated.

~~For issue #53; this will conflict with PR #52.  I can update it after #52 is closed or a maintainer can add these changes themselves; it's pretty straightforward.~~

**2016-04-10** - rebased after #52 and #55 were merged into master.