### PR TITLE
Use proxy object to prevent strong reference cycle

### DIFF
--- a/Source/AnimatableImageView.swift
+++ b/Source/AnimatableImageView.swift
@@ -2,11 +2,28 @@ import UIKit
 
 /// A subclass of `UIImageView` that can be animated using an image name string or raw data.
 public class AnimatableImageView: UIImageView {
+
+  /// Proxy object for preventing a reference cycle between the CADisplayLink and AnimatableImageView.
+  /// Source: http://merowing.info/2015/11/the-beauty-of-imperfection/
+  class TargetProxy {
+
+    private weak var target: AnimatableImageView!
+
+    init(target: AnimatableImageView) {
+      self.target = target
+    }
+
+    @objc func onScreenUpdate(dl: CADisplayLink) {
+      target.updateFrame()
+    }
+  }
+
   /// An `Animator` instance that holds the frames of a specific image in memory.
   var animator: Animator?
+
   /// A display link that keeps calling the `updateFrame` method on every screen refresh.
   lazy var displayLink: CADisplayLink = {
-    let display = CADisplayLink(target: self, selector: #selector(updateFrame))
+    let display = CADisplayLink(target: TargetProxy(target: self), selector: #selector(TargetProxy.onScreenUpdate(_:)))
     display.paused = true
     return display
   }()
@@ -16,7 +33,7 @@ public class AnimatableImageView: UIImageView {
 
   /// Specifies whether the GIF frames should be pre-scaled to save memory. Default is **true**.
   public var needsPrescaling = true
-  
+
   /// A computed property that returns whether the image view is animating.
   public var isAnimatingGIF: Bool {
     return !displayLink.paused
@@ -26,7 +43,7 @@ public class AnimatableImageView: UIImageView {
   public var frameCount: Int {
     return animator?.frameCount ?? 0
   }
-  
+
   /// Prepares the frames using a GIF image file name, without starting the animation.
   /// The file name should include the `.gif` extension.
   ///
@@ -79,7 +96,7 @@ public class AnimatableImageView: UIImageView {
   public func stopAnimatingGIF() {
     displayLink.paused = true
   }
-  
+
   /// Reset the image view values
   public func prepareForReuse() {
     stopAnimatingGIF()
@@ -93,8 +110,9 @@ public class AnimatableImageView: UIImageView {
     }
   }
 
-  /// Invalidate the displayLink so it releases this object.
+  /// Invalidate the displayLink so it releases its target.
   deinit {
+    // invalidate will also remove the link from all run loops
     displayLink.invalidate()
   }
 
@@ -102,5 +120,5 @@ public class AnimatableImageView: UIImageView {
   func attachDisplayLink() {
     displayLink.addToRunLoop(.mainRunLoop(), forMode: NSRunLoopCommonModes)
   }
-}
 
+}


### PR DESCRIPTION
This is a fix for the memory leak issue described [in this comment](https://github.com/kaishin/Gifu/issues/12#issuecomment-203968348) on issue #12.

Although the `deinit` block called `displayLink.invalidate()`, because the CADisplayLink was retaining the AnimatableImageView instance the view was never deallocated, its deinit block never executed, and `.invalidate()` was never called.

We can fix the retention cycle between AnimatableImageView and CADisplayLink by using another object as the target for the CADisplayLink instance, as described [here](http://merowing.info/2015/11/the-beauty-of-imperfection/#animation:2ef054e1986c78a07cd2936c4a6d6e4a).

Here is the Instrument trace showing my [test application](https://github.com/mr-seiler/gifu-bug-demo) running with this patch: [gifu-leak-fixed.trace.zip](https://github.com/kaishin/Gifu/files/198270/gifu-leak-fixed.trace.zip).  (Compare with the original trace from the comment linked above: [gifu-leak-demo.trace.zip](https://github.com/kaishin/Gifu/files/197862/gifu-leak-demo.trace.zip))

Screenshot of instrument results:
![screen shot 2016-03-31 at 1 48 00 pm](https://cloud.githubusercontent.com/assets/2651651/14185423/bc97ef4a-f747-11e5-8119-f60ef6384146.png)
