### PR TITLE
Fix documentation URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ it using `imageView.startAnimatingGIF()`.
 
 The `isAnimatingGIF()` method returns the current animation state of the view if it has an animatable image.
 
-See the [full documentation](http://kaishin.github.io/gifu/).
+See the [full documentation](http://kaishin.github.io/Gifu/).
 
 #### Demo App
 


### PR DESCRIPTION
The was a typo in README.md that took you to a 404! This PR updates the URL with the correct address.