### PR TITLE
Fix crash when frames not preloaded in time.

### DIFF
--- a/GifuTests/GifuTests.swift
+++ b/GifuTests/GifuTests.swift
@@ -20,6 +20,12 @@ class GifuTests: XCTestCase {
     XCTAssertTrue(animator.isAnimatable)
   }
 
+  func testCurrentFrame() {
+    XCTAssertEqual(animator.currentFrameIndex, 0)
+    XCTAssertEqual(animator.currentFrameDuration, NSTimeInterval.infinity)
+    XCTAssertNil(animator.currentFrameImage)
+  }
+
   func testFramePreload() {
     let expectation = expectationWithDescription("frameDuration")
 

--- a/Source/Animator.swift
+++ b/Source/Animator.swift
@@ -92,7 +92,7 @@ class Animator {
   /// - parameter index: The index of the duration.
   /// - returns: The duration of the given frame.
   func durationAtIndex(index: Int) -> NSTimeInterval {
-    return animatedFrames[index].duration
+	return animatedFrames[safe: index]?.duration ?? NSTimeInterval.infinity
   }
 
   /// Checks whether the frame should be changed and calls a handler with the results.


### PR DESCRIPTION
Added a test to demonstrate that calling `currentFrameDuration` will cause a fatal error if preloading hasn’t begun for the frame when accessing its value (which happens intermittently due to frames being preloaded on a background thread, and animation occurring on the main thread), which seems to be the underlying cause of issue #66.

By returning a valid value if the frame duration is not available, in this case `NSTimeInterval.infinity`. This can cause a lag if preloading takes too long, but my on-device tests have shown this to be negligible (and a far better result than crashing).