### PR TITLE
Allow specifying a custom bundle

### DIFF
--- a/Source/Classes/Animator.swift
+++ b/Source/Classes/Animator.swift
@@ -65,14 +65,15 @@ public class Animator {
 
   /// Prepares the animator instance for animation.
   ///
-  /// - parameter imageName: The file name of the GIF in the main bundle.
+  /// - parameter imageName: The file name of the GIF in the specified bundle.
+  /// - parameter bundle: The bundle where the GIF is located (default Bundle.main).
   /// - parameter size: The target size of the individual frames.
   /// - parameter contentMode: The view content mode to use for the individual frames.
   /// - parameter loopCount: Desired number of loops, <= 0 for infinite loop.
   /// - parameter completionHandler: Completion callback function
-  func prepareForAnimation(withGIFNamed imageName: String, size: CGSize, contentMode: UIView.ContentMode, loopCount: Int = 0, completionHandler: (() -> Void)? = nil) {
+  func prepareForAnimation(withGIFNamed imageName: String, inBundle bundle: Bundle = .main, size: CGSize, contentMode: UIView.ContentMode, loopCount: Int = 0, completionHandler: (() -> Void)? = nil) {
     guard let extensionRemoved = imageName.components(separatedBy: ".")[safe: 0],
-      let imagePath = Bundle.main.url(forResource: extensionRemoved, withExtension: "gif"),
+      let imagePath = bundle.url(forResource: extensionRemoved, withExtension: "gif"),
       let data = try? Data(contentsOf: imagePath) else { return }
 
     prepareForAnimation(withGIFData: data,

--- a/Supporting Files/Info.plist
+++ b/Supporting Files/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>152</string>
+	<string>153</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Most of the code in the app I work on is in a framework with its own bundle. Given that all of our other assets are stored in that framework's bundle, it's beneficial to store our GIFs there as well. However, before this change, we had to use the prepareForAnimation(withGIFData:...) method. 

With this change, it's now possible for us to do `prepareForAnimation(withGIFNamed: "flipper", inBundle: .framework)` which is really nice and clean.

If you think other folks would find this useful, let's merge it in!