### PR TITLE
GIFImageView: add missing call to super

### DIFF
--- a/Sources/Gifu/Classes/GIFImageView.swift
+++ b/Sources/Gifu/Classes/GIFImageView.swift
@@ -12,7 +12,9 @@ public class GIFImageView: UIImageView, GIFAnimatable {
   ///
   /// - parameter layer: The delegated layer.
   override public func display(_ layer: CALayer) {
-    super.display(layer)
+    if super.responds(to: #selector(display(_:))) {
+        super.display(layer)
+    }
     updateImageIfNeeded()
   }
 }

--- a/Sources/Gifu/Classes/GIFImageView.swift
+++ b/Sources/Gifu/Classes/GIFImageView.swift
@@ -12,6 +12,7 @@ public class GIFImageView: UIImageView, GIFAnimatable {
   ///
   /// - parameter layer: The delegated layer.
   override public func display(_ layer: CALayer) {
+    super.display(layer)
     updateImageIfNeeded()
   }
 }

--- a/Sources/Gifu/Classes/GIFImageView.swift
+++ b/Sources/Gifu/Classes/GIFImageView.swift
@@ -12,7 +12,7 @@ public class GIFImageView: UIImageView, GIFAnimatable {
   ///
   /// - parameter layer: The delegated layer.
   override public func display(_ layer: CALayer) {
-    if super.responds(to: #selector(display(_:))) {
+    if UIImageView.instancesRespond(to: #selector(display(_:))) {
         super.display(layer)
     }
     updateImageIfNeeded()


### PR DESCRIPTION
Building my app in Xcode 12 beta 1, I noticed that none of my images were appearing.

I found that this call to super in `display(_ layer: CALayer)` is important in iOS 14 - and suspect it is probably safe/good to have in previous versions too.