### PR TITLE
Removed version number generation

### DIFF
--- a/Gifu.xcodeproj/project.pbxproj
+++ b/Gifu.xcodeproj/project.pbxproj
@@ -212,7 +212,6 @@
 				00B8C73A1A364DA400C188E7 /* Frameworks */,
 				00B8C73B1A364DA400C188E7 /* Headers */,
 				00B8C73C1A364DA400C188E7 /* Resources */,
-				003DD00A1C4FB0E600C7E06B /* Set Version Number */,
 			);
 			buildRules = (
 			);
@@ -283,23 +282,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		003DD00A1C4FB0E600C7E06B /* Set Version Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Version Number";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "GIT_RELEASE_VERSION=$(git describe --tags --always --abbrev=0)\nCOMMITS=$(git rev-list HEAD | wc -l)\nCOMMITS=$(($COMMITS))\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion ${COMMITS}\" \"${INFOPLIST_FILE}\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${GIT_RELEASE_VERSION#*v}\" \"${INFOPLIST_FILE}\"";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		009BD1321BBC7F6500FC982B /* Sources */ = {


### PR DESCRIPTION
Removed version number generation causing changes to occur when used with Carthage or Submodules. We're running into this as we use submodules and it's causing frustrating delays in committing changes.

The library is great so it would be awesome to have this merged in!

Fixes #157 