### PR TITLE
Issue #164: Introduces defaultFrameRate

### DIFF
--- a/Sources/Gifu/Helpers/ImageSourceHelpers.swift
+++ b/Sources/Gifu/Helpers/ImageSourceHelpers.swift
@@ -4,29 +4,41 @@ import MobileCoreServices
 import UIKit
 
 typealias GIFProperties = [String: Double]
-let defaultDuration: Double = 0
+
+/// Most GIFs run between 15 and 24 Frames per second.
+///
+/// If a GIF does not have (frame-)durations stored in its metadata,
+/// this default framerate is used to calculate the GIFs duration.
+private let defaultFrameRate: Double = 15.0
+
+/// Default Fallback Frame-Duration based on `defaultFrameRate`
+private let defaultFrameDuration: Double = 1 / defaultFrameRate
+
+/// Threshold used in `capDuration` for a FrameDuration
+private let capDurationThreshold: Double = 0.02 - Double.ulpOfOne
+
+/// Frameduration used, if a frame-duration is below `capDurationThreshold`
+private let minFrameDuration: Double = 0.1
 
 /// Retruns the duration of a frame at a specific index using an image source (an `CGImageSource` instance).
 ///
 /// - returns: A frame duration.
 func CGImageFrameDuration(with imageSource: CGImageSource, atIndex index: Int) -> TimeInterval {
-  if !imageSource.isAnimatedGIF { return 0.0 }
-
+  guard imageSource.isAnimatedGIF else { return 0.0 }
+  
+  // Return nil, if the properties do not store a FrameDuration or FrameDuration <= 0
   guard let GIFProperties = imageSource.properties(at: index),
-    let duration = frameDuration(with: GIFProperties),
-    let cappedDuration = capDuration(with: duration)
-    else { return defaultDuration }
-
-  return cappedDuration
+        let duration = frameDuration(with: GIFProperties),
+        duration > 0 else { return defaultFrameDuration }
+  
+  return capDuration(with: duration)
 }
 
 /// Ensures that a duration is never smaller than a threshold value.
 ///
 /// - returns: A capped frame duration.
-func capDuration(with duration: Double) -> Double? {
-  if duration < 0 { return nil }
-  let threshold = 0.02 - Double.ulpOfOne
-  let cappedDuration = duration < threshold ? 0.1 : duration
+func capDuration(with duration: Double) -> Double {
+  let cappedDuration = duration < capDurationThreshold ? 0.1 : duration
   return cappedDuration
 }
 
@@ -35,18 +47,18 @@ func capDuration(with duration: Double) -> Double? {
 /// - returns: A frame duration.
 func frameDuration(with properties: GIFProperties) -> Double? {
   guard let unclampedDelayTime = properties[String(kCGImagePropertyGIFUnclampedDelayTime)],
-    let delayTime = properties[String(kCGImagePropertyGIFDelayTime)]
-    else { return nil }
-
+        let delayTime = properties[String(kCGImagePropertyGIFDelayTime)]
+  else { return nil }
+  
   return duration(withUnclampedTime: unclampedDelayTime, andClampedTime: delayTime)
 }
 
 /// Calculates frame duration based on both clamped and unclamped times.
 ///
 /// - returns: A frame duration.
-func duration(withUnclampedTime unclampedDelayTime: Double, andClampedTime delayTime: Double) -> Double {
+func duration(withUnclampedTime unclampedDelayTime: Double, andClampedTime delayTime: Double) -> Double? {
   let delayArray = [unclampedDelayTime, delayTime]
-  return delayArray.filter({ $0 >= 0 }).first ?? defaultDuration
+  return delayArray.filter({ $0 >= 0 }).first
 }
 
 /// An extension of `CGImageSourceRef` that adds GIF introspection and easier property retrieval.
@@ -59,7 +71,7 @@ extension CGImageSource {
     let imageCount = CGImageSourceGetCount(self)
     return isTypeGIF != false && imageCount > 1
   }
-
+  
   /// Returns the GIF properties at a specific index.
   ///
   /// - parameter index: The index of the GIF properties to retrieve.
@@ -69,4 +81,5 @@ extension CGImageSource {
     return imageProperties[String(kCGImagePropertyGIFDictionary)] as? GIFProperties
   }
 }
+
 #endif


### PR DESCRIPTION
My request is resolving [this issue](https://github.com/kaishin/Gifu/issues/164).

- Replaces  **defaultDuration** with **defaultFrameRate**:
Instead of a fixed _defaultDuration_ as fallback-solution for GIFs without duration-metadata,
frame-durations are now calculated using a specified defaultFrameRate (set to 15 FPS).

> Most GIFs usually play at a Framerate between 15 and 24FPS, with 15FPS being the most common one. [Source](https://www.bluefrogdm.com/blog/best-practices-for-creating-animated-gifs#:~:text=Standard%20GIFs%20run%20between%2015%20and%2024%20frames%20per%20second.&text=Overall%2C%20the%20smaller%20your%20GIF,lower%20the%20quality%20will%20be.)
> Even macOS Catalina Quick-Preview uses 15FPS as fallback FPS-value, if a GIF does not provide duration metadata.

- Minor refactoring:
Sometimes, 2 or 4 spaces were used as tab-width in ImageSourceHelpers.swift-> unified them to 2 spaces.
Moved capDurationThreshold out of capDuration, so it won't be re-calculated on every function-call.