### PR TITLE
Don't attempt to resize zero-size frame images.

### DIFF
--- a/Sources/Gifu/Classes/FrameStore.swift
+++ b/Sources/Gifu/Classes/FrameStore.swift
@@ -164,7 +164,7 @@ private extension FrameStore {
       switch self.contentMode {
       case .scaleAspectFit: scaledImage = image.constrained(by: size)
       case .scaleAspectFill: scaledImage = image.filling(size: size)
-      default: scaledImage = image.resized(to: size)
+      default: scaledImage = size != .zero ? image.resized(to: size) : nil
       }
     } else {
       scaledImage = image


### PR DESCRIPTION
We were seeing a lot of spurious console logs related to zero-size image resizing.  I added code to skip the resize if the target size is zero, and this fixed the issue.