### PR TITLE
[Draft] Add SwiftUI Support

### DIFF
--- a/Gifu.xcodeproj/project.pbxproj
+++ b/Gifu.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		00B8C7961A3650EE00C188E7 /* Gifu.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B8C7951A3650EE00C188E7 /* Gifu.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00BF42CC1D99A1DC00C6F28D /* GIFAnimatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BF42CB1D99A1DC00C6F28D /* GIFAnimatable.swift */; };
 		00DD26EE1DA9643800A0F683 /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DD26ED1DA9643800A0F683 /* UIImageView.swift */; };
+		0CB347CF29909D830071DA4B /* GIFImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB347CE29909D830071DA4B /* GIFImage.swift */; };
 		A5D726EA28B53D6400821347 /* earth.gif in Resources */ = {isa = PBXBuildFile; fileRef = A5D726E928B53D6400821347 /* earth.gif */; };
 		EAF49C7F1A3A4DE000B395DF /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF49C7E1A3A4DE000B395DF /* UIImage.swift */; };
 		EAF49CB11A3B6EEB00B395DF /* AnimatedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF49CB01A3B6EEB00B395DF /* AnimatedFrame.swift */; };
@@ -53,6 +54,7 @@
 		00BF42CB1D99A1DC00C6F28D /* GIFAnimatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GIFAnimatable.swift; sourceTree = "<group>"; };
 		00C50CFB2392BA9900CBE23C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		00DD26ED1DA9643800A0F683 /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
+		0CB347CE29909D830071DA4B /* GIFImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFImage.swift; sourceTree = "<group>"; };
 		A5D726E928B53D6400821347 /* earth.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = earth.gif; sourceTree = "<group>"; };
 		EAF49C7E1A3A4DE000B395DF /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		EAF49CB01A3B6EEB00B395DF /* AnimatedFrame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedFrame.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				005656EC1A6F14D6008A0ED1 /* FrameStore.swift */,
 				00BF42CB1D99A1DC00C6F28D /* GIFAnimatable.swift */,
 				005656EE1A6F1C26008A0ED1 /* GIFImageView.swift */,
+				0CB347CE29909D830071DA4B /* GIFImage.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 				009BD1441BBC93C800FC982B /* CGSize.swift in Sources */,
 				EAF49CB11A3B6EEB00B395DF /* AnimatedFrame.swift in Sources */,
 				00B8C75F1A364DCE00C188E7 /* ImageSourceHelpers.swift in Sources */,
+				0CB347CF29909D830071DA4B /* GIFImage.swift in Sources */,
 				00DD26EE1DA9643800A0F683 /* UIImageView.swift in Sources */,
 				00978B6C1D9C6D2A00A6575F /* Animator.swift in Sources */,
 				007E08441BD95E6200883D0C /* Array.swift in Sources */,

--- a/Sources/Gifu/Classes/GIFImage.swift
+++ b/Sources/Gifu/Classes/GIFImage.swift
@@ -1,0 +1,53 @@
+#if os(iOS) || os(tvOS)
+import SwiftUI
+
+/// An image view for displaying animated images.
+@available(iOS 13, tvOS 13, *)
+public struct GIFImage: UIViewRepresentable {
+    private enum Source {
+        case data(Data)
+        case url(URL)
+        case imageName(String)
+    }
+
+    private let source: Source
+    private var loopCount = 0
+
+    /// Initializes the view with the given GIF image data.
+    public init(data: Data) {
+        self.source = .data(data)
+    }
+
+    /// Initialzies the view with the given GIF image url.
+    public init(url: URL) {
+        self.source = .url(url)
+    }
+
+    /// Initialzies the view with the given GIF image name.
+    public init(imageName: String) {
+        self.source = .imageName(imageName)
+    }
+
+    /// Sets the desired number of loops. By default, the number of loops infinite.
+    public func loopCount(_ value: Int) -> GIFImage {
+        var copy = self
+        copy.loopCount = value
+        return copy
+    }
+
+    public func makeUIView(context: Context) -> GIFImageView {
+        GIFImageView(frame: .zero)
+    }
+
+    public func updateUIView(_ view: GIFImageView, context: Context) {
+        switch source {
+        case .data(let data):
+            view.animate(withGIFData: data, loopCount: loopCount)
+        case .url(let url):
+            view.animate(withGIFURL: url, loopCount: loopCount)
+        case .imageName(let imageName):
+            view.animate(withGIFNamed: imageName, loopCount: loopCount)
+        }
+    }
+}
+#endif

--- a/Sources/Gifu/Classes/GIFImage.swift
+++ b/Sources/Gifu/Classes/GIFImage.swift
@@ -3,15 +3,10 @@ import SwiftUI
 
 /// An image view for displaying animated images.
 @available(iOS 13, tvOS 13, *)
-public struct GIFImage: UIViewRepresentable {
-    private enum Source {
-        case data(Data)
-        case url(URL)
-        case imageName(String)
-    }
-
-    private let source: Source
+public struct GIFImage: View {
+    private let source: GIFSource
     private var loopCount = 0
+    private var isResizable = false
 
     /// Initializes the view with the given GIF image data.
     public init(data: Data) {
@@ -35,19 +30,52 @@ public struct GIFImage: UIViewRepresentable {
         return copy
     }
 
-    public func makeUIView(context: Context) -> GIFImageView {
-        GIFImageView(frame: .zero)
+    /// Sets an image to fit its space.
+    public func resizable() -> GIFImage {
+        var copy = self
+        copy.isResizable = true
+        return copy
     }
 
-    public func updateUIView(_ view: GIFImageView, context: Context) {
+    public var body: some View {
+        _GIFImage(source: source, loopCount: loopCount, isResizable: isResizable)
+    }
+}
+
+@available(iOS 13, tvOS 13, *)
+private struct _GIFImage: UIViewRepresentable {
+    let source: GIFSource
+    let loopCount: Int
+    let isResizable: Bool
+
+    func makeUIView(context: Context) -> GIFImageView {
+        let imageView = GIFImageView()
+        if isResizable {
+            imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        }
+        return imageView
+    }
+
+    func updateUIView(_ imageView: GIFImageView, context: Context) {
         switch source {
         case .data(let data):
-            view.animate(withGIFData: data, loopCount: loopCount)
+            imageView.animate(withGIFData: data, loopCount: loopCount)
         case .url(let url):
-            view.animate(withGIFURL: url, loopCount: loopCount)
+            imageView.animate(withGIFURL: url, loopCount: loopCount)
         case .imageName(let imageName):
-            view.animate(withGIFNamed: imageName, loopCount: loopCount)
+            imageView.animate(withGIFNamed: imageName, loopCount: loopCount)
         }
     }
+
+    static func dismantleUIView(_ imageView: GIFImageView, coordinator: ()) {
+        imageView.prepareForReuse()
+    }
+}
+
+private enum GIFSource {
+    case data(Data)
+    case url(URL)
+    case imageName(String)
 }
 #endif


### PR DESCRIPTION
Adds `GIFImage` (SwiftUI support).

TODO: 

- I'm not sure `dismantleUIView` is needed. `GIFImageView` gets deallocated, so presumably, it clears resources automatically.
- I tested `dismantleUIView` in a `List`. It gets called, but not at the same time as `onDisappear`, which gets called earlier. I'm thinking about removing `dismantleUIView` and adding `onAppear` and  `onDisappear` instead (not very easy to do). The goal is to stop playing the image as soon as it's not on the screen.
- Q: should `onDisappear` behavior be configurable?
- I don't like the whole `isResizable` thing, but without it, the image view (`GIFImageView`) simply ignores its container frame – the same way as `SwiftUI.Image`.
- I've completed some smoke tests but not nearly enough.